### PR TITLE
Update the paper names to be actual URLs. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ What
 ----
 
 Programming language researchers investigate the analysis, design,
-implementation, and evaluation of programming languages. Our goal 
-is that the papers come from all of these areas. 
+implementation, and evaluation of programming languages. Our goal
+is that the papers come from all of these areas.
 
 Why
 ---
@@ -16,87 +16,76 @@ the others disagrees.
 
 A paper may make it on the list if it is a milestone in the intellectual
 history of programming languages, if it is a good paper, and if its ideas
-are still good today. 
+are still good today.
 
-A paper may make it on the list if it covers an area particularly well. 
+A paper may make it on the list if it covers an area particularly well.
 
 A paper may make it on the list if a PhD student in PL should know about
-this topic---even if it is outside of the confines of PL. 
+this topic---even if it is outside of the confines of PL.
 
 A paper on this list may not be *not* essential to obtaining a PhD in
 PL. It is unlikely to introduce you to modern ways of dealing with a
 topic. It is unlikely to be fashionable. It is improbable that you will
 cite it in your dissertation. But, all of us consider it worth your
-while. Reading it is good for your soul. 
+while. Reading it is good for your soul.
 
-The List of Papers 
+The List of Papers
 ------------------
 
 [listed in alphabetical order of the first author's last name]
 
 L. Cardelli.
-Type systems. 
-Handbook of Computer Science and Engineering, 1997, 2208-2236.
-[url](http://lucacardelli.name/papers/typesystems.pdf)
+Type systems.
+[Handbook of Computer Science and Engineering](http://lucacardelli.name/papers/typesystems.pdf), 1997, 2208-2236.
 
 C. Chambers and D. Ungar.
-Customization: Optimizing Compiler Technology for SELF, 
-a Dynamically-typed Object-oriented Programming Language.
+[Customization: Optimizing Compiler Technology for SELF,
+a Dynamically-typed Object-oriented Programming Language.](http://dl.acm.org/citation.cfm?id=74831)
 PLDI 1989, 146--160.
-[url](http://dl.acm.org/citation.cfm?id=74831)
 
 P. Cousot and R. Cousot.
-Abstract interpretation: a unified lattice model for static analysis of
-programs by construction or approximation of fixpoints. 
+[Abstract interpretation: a unified lattice model for static analysis of
+programs by construction or approximation of fixpoints.](http://dl.acm.org/citation.cfm?id=512973)
 Principles of Programming Languages, 1977, 238--252.
-[url](http://dl.acm.org/citation.cfm?id=512973)
 
 C.A.R. Hoare.
-An axiomatic basis for computer programming. 
+[An axiomatic basis for computer programming.](http://dl.acm.org/citation.cfm?id=363259)
 Communications of the ACM, 1969, 12(10), 576-–580.
-[url](http://dl.acm.org/citation.cfm?id=363259)
 
 C.A.R. Hoare.
-Proof of correctness of data representations.
+[Proof of correctness of data representations.](http://link.springer.com/article/10.1007%2FBF00289507#page-1)
 Acta Informatica, 1972, 1, 271--281.
-[url](http://link.springer.com/article/10.1007%2FBF00289507#page-1)
 
 G.A. Kildall
-A Unified approach to global program optimization.
+[A Unified approach to global program optimization.](http://dl.acm.org/citation.cfm?id=512945)
 Principles of Programming Languages, 1973, 194--206.
-[url](http://dl.acm.org/citation.cfm?id=512945)
 
-P.J. Landin 
-The next 700 programming languages. 
+P.J. Landin
+[The next 700 programming languages.](http://dl.acm.org/citation.cfm?id=365257)
 Communications of the ACM, 1966, 9(3), 157--166.
-[url](http://dl.acm.org/citation.cfm?id=365257)
 
 J.H. Morris, Jr. and Ben Wegbreit.
-Subgoal induction.
+[Subgoal induction.](http://dl.acm.org/citation.cfm?id=359466)
 Communications of the ACM, 1977, 20(4), 209--222.
-[url](http://dl.acm.org/citation.cfm?id=359466)
 
 G. Morrisett, D. Walker, K. Crary, and N. Glew.
-From system F to typed assembly language.
+[From system F to typed assembly language.](http://dl.acm.org/citation.cfm?id=319345)
 Transactions on Programming Languages and Systems, 1999, 21 (3), 527--568.
-[url](http://dl.acm.org/citation.cfm?id=319345)
 
 D.L. Parnas
-On the criteria to be used in decomposing systems into modules.
+[On the criteria to be used in decomposing systems into modules.](http://dl.acm.org/citation.cfm?id=361623)
 Communications of the ACM, 1972, 15(12), 1053--1058.
-[url](http://dl.acm.org/citation.cfm?id=361623)
 
 G.D. Plotkin.
-Call-by-name, call-by-value, and the λ-calculus.
+[Call-by-name, call-by-value, and the λ-calculus.](http://homepages.inf.ed.ac.uk/gdp/publications/cbn_cbv_lambda.pdf)
 Theoretical Computer Science 1 (1975), 125--159.
-[url](http://homepages.inf.ed.ac.uk/gdp/publications/cbn_cbv_lambda.pdf)
 
 ----
 ## changelog
 * Tue Oct 20 23:06:27 EDT 2015 " added Amal's "white ball"
 * Tue Oct 20 21:13:13 EDT 2015 " added "modules", removed "Reynolds" based
-on discussion by Amal, Olin, and Matthias; added Olin's choices 
-* Tue Oct 20 16:59:02 EDT 2015  " added Mitch's suggestions 
-* Fri Oct 16 12:47:38 EDT 2015  " added Will's suggestions 
+on discussion by Amal, Olin, and Matthias; added Olin's choices
+* Tue Oct 20 16:59:02 EDT 2015  " added Mitch's suggestions
+* Fri Oct 16 12:47:38 EDT 2015  " added Will's suggestions
 * Fri Oct 16 09:48:17 EDT 2015 Matthias creates and populates the
 repository with Amal's, Jan's, and his own ideas

--- a/mf-s-list.md
+++ b/mf-s-list.md
@@ -20,7 +20,7 @@ precision, acknowledgment of historical debt, or sloppy writing.
 Nevertheless, they left an impression, so they have somehow become a part
 of the group's vocabulary. In addition, learning to distinguish good papers
 from "must read even though I dislike them" papers may help you develop
-your own taste. 
+your own taste.
 
 **Note** A paper on this list may not be not essential to your dissertation
 research. It is unlikely to introduce you to modern ways of dealing with my
@@ -28,139 +28,117 @@ topics of interest. It is unlikely to be fashionable. It is improbable that
 you will cite it in your dissertation. But, I consider the paper worth your
 while; reading it is good for your soul.
 
-Vision 
+Vision
 ------
 
-Felleisen, Findler, Flatt, Krishnamurthi, Barzilay, McCarthy, Tobin-Hochstadt. 
-The Racket Manifesto. 
-SNAPL 2015. 
-[url](http://www.ccs.neu.edu/home/matthias/manifesto/)
+Felleisen, Findler, Flatt, Krishnamurthi, Barzilay, McCarthy, Tobin-Hochstadt.
+[The Racket Manifesto.](http://www.ccs.neu.edu/home/matthias/manifesto/)
+SNAPL 2015.
 
-Syntax Extensions and Macros 
+Syntax Extensions and Macros
 ----------------------------
 
-Dybvig, Hieb, and Bruggeman. 
-Syntactic abstraction in Scheme. 
+Dybvig, Hieb, and Bruggeman.
+[Syntactic abstraction in Scheme.](http://link.springer.com/article/10.1007%2FBF01806308#page-1)
 Lisp and Symbolic Computation,1993. 5(4), 295-–326.
-[url](http://link.springer.com/article/10.1007%2FBF01806308#page-1)
 
-Flatt. 
-Composable and compilable macros:: you want it when?
+Flatt.
+[Composable and compilable macros:: you want it when?](http://dl.acm.org/citation.cfm?id=581486)
 ICFP 2002, 72--83.
-[url](http://dl.acm.org/citation.cfm?id=581486)
 
-Flatt. 
+Flatt.
 Binding as Sets of Scopes.
 POPL 2016, ??--??.
-[url](to appear)
 
 Gradual Typing [Language Design]
 --------------------------------
 
-Fagan and Cartwright. 
-Soft typing. 
+Fagan and Cartwright.
+[Soft typing.](http://dl.acm.org/citation.cfm?id=113445.113469&coll=DL&dl=ACM&CFID=723280388&CFTOKEN=84457028)
 PLDI 1991, 278--292.
-[url](http://dl.acm.org/citation.cfm?id=113445.113469&coll=DL&dl=ACM&CFID=723280388&CFTOKEN=84457028)
 
-Flanagan. 
-Hybrid type checking. 
+Flanagan.
+[Hybrid type checking.](http://dl.acm.org/citation.cfm?id=1111059)
 POPL 2006, 245--256.
-[url](http://dl.acm.org/citation.cfm?id=1111059)
 
 Gray, Findler, Flatt.
-Fine-grained interoperability through mirrors and contracts.
-OOPSLA 2005, 231--245. 
-[url](http://dl.acm.org/citation.cfm?id=1094830)
+[Fine-grained interoperability through mirrors and contracts.](http://dl.acm.org/citation.cfm?id=1094830)
+OOPSLA 2005, 231--245.
 
-Matthews and Findler. 
-Operational semantics for multi-language programs. 
+Matthews and Findler.
+[Operational semantics for multi-language programs.](http://dl.acm.org/citation.cfm?id=1498926.1498930&coll=DL&dl=ACM&CFID=723280388&CFTOKEN=84457028)
 Transactions on Programming Languages and Systems 2009, 31(3), 1--44.
-[url](http://dl.acm.org/citation.cfm?id=1498926.1498930&coll=DL&dl=ACM&CFID=723280388&CFTOKEN=84457028)
 
-Siek and Taha. 
-Gradual typing for functional languages. 
-Scheme and Functional Programming, 2006, 81--92. 
-[url](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.61.8890)
+Siek and Taha.
+[Gradual typing for functional languages.](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.61.8890)
+Scheme and Functional Programming, 2006, 81--92.
 Note: read with [Tobin-Hochstadt/Felleisen, DLS, 2006](http://dl.acm.org/citation.cfm?id=1176755)
 
-Wright and Cartwright. 
-A practical soft type system for Scheme.
+Wright and Cartwright.
+[A practical soft type system for Scheme.](http://dl.acm.org/citation.cfm?id=239912.239917&coll=DL&dl=ACM&CFID=723280388&CFTOKEN=84457028)
 Transactions on Programming Languages and Systems 1997, 19(1), 87--152.
-[url](http://dl.acm.org/citation.cfm?id=239912.239917&coll=DL&dl=ACM&CFID=723280388&CFTOKEN=84457028)
 
 Modules and Mixins [Language Design]
 ------------------------------------
 
 Bracha and Cook.
-Mixin-based inheritance.
-OOPSLA/ECCOP 1990, 303--311. 
-[url](http://dl.acm.org/citation.cfm?id=97982)
+[Mixin-based inheritance.](http://dl.acm.org/citation.cfm?id=97982)
+OOPSLA/ECCOP 1990, 303--311.
 
-Harper and Lillibridge. 
-A type-theoretic approach to higher-order modules with sharing. 
+Harper and Lillibridge.
+[A type-theoretic approach to higher-order modules with sharing.](http://dl.acm.org/citation.cfm?id=174675.176927&coll=DL&dl=ACM&CFID=723280388&CFTOKEN=84457028)
 POPL 1994, 123--137.
-[url](http://dl.acm.org/citation.cfm?id=174675.176927&coll=DL&dl=ACM&CFID=723280388&CFTOKEN=84457028)
 
-Leroy. 
-Manifest types, modules, and separate compilation. 
+Leroy.
+[Manifest types, modules, and separate compilation.](http://dl.acm.org/citation.cfm?id=174675.176926&coll=DL&dl=ACM&CFID=723280388&CFTOKEN=84457028)
 POPL 1994, 109--122.
-[url](http://dl.acm.org/citation.cfm?id=174675.176926&coll=DL&dl=ACM&CFID=723280388&CFTOKEN=84457028)
 
-Performance Evaluation 
+Performance Evaluation
 ----------------------
 
 Georges, Buytaert, and Eeckhout.
-Statistically rigorous Java performance evaluation.
+[Statistically rigorous Java performance evaluation.](http://dl.acm.org/citation.cfm?id=1297033)
 OOPSLA 2007, 57--76.
-[url](http://dl.acm.org/citation.cfm?id=1297033)
 
 Mytkowicz, Diwan, Hauswirth, and Sweeney.
-Producing wrong data without doing anything obviously wrong!
+[Producing wrong data without doing anything obviously wrong!](http://dl.acm.org/citation.cfm?id=1508275)
 ASPLOS 2009, 265--276.
-[url](http://dl.acm.org/citation.cfm?id=1508275)
 
 Vitek and Kalibera.
-R3: Repeatability, Reproducibility and Rigor.
+[R3: Repeatability, Reproducibility and Rigor.](http://dl.acm.org/citation.cfm?id=2442781)
 SIGPLAN Noices 2012 47(4a), 30--36.
-[url](http://dl.acm.org/citation.cfm?id=2442781)
 
-Blackburn et al. 
-The DaCapo benchmarks: Java benchmarking development and analysis.
+Blackburn et al.
+[The DaCapo benchmarks: Java benchmarking development and analysis.](http://dl.acm.org/citation.cfm?id=1167488)
 OOPSLA 2006, 169--190.
-[url](http://dl.acm.org/citation.cfm?id=1167488)
 
-Semantics 
+Semantics
 ---------
 
-Plotkin. 
-LCF considered a programming language. 
+Plotkin.
+[LCF considered a programming language.](http://homepages.inf.ed.ac.uk/gdp/publications/LCF.pdf)
 Theoretical Computer Science, 1977, 5, 223--255.
-[url](http://homepages.inf.ed.ac.uk/gdp/publications/LCF.pdf)
 
 Books You Should Know Before You Start
 --------------------------------------
 
 One of:
 
-* Krishnamurthi. 
-Programming Languages: Applications and Implementations. 
-[url](https://cs.brown.edu/~sk/Publications/Books/ProgLangs/2007-04-26/)
+* Krishnamurthi.
+[Programming Languages: Applications and Implementations.](https://cs.brown.edu/~sk/Publications/Books/ProgLangs/2007-04-26/)
 
-* Friedman and Wand. 
-Essentials of Programming Languages. 
-[url](http://www.eopl3.com)
+* Friedman and Wand.
+[Essentials of Programming Languages.](http://www.eopl3.com)
 
-Felleisen, Findler, Flatt. 
-Semantics Engineering [Parts I and II].
-MIT Press. 2011. 
-[url](http://redex.racket-lang.org)
+Felleisen, Findler, Flatt.
+[Semantics Engineering [Parts I and II].](http://redex.racket-lang.org)
+MIT Press. 2011.
 
-Pierce. 
-Types and Programming Languages. 
+Pierce.
+[Types and Programming Languages. ](http://www.cis.upenn.edu/~bcpierce/tapl/index.html)
 MIT Press, 2002.
-[url](http://www.cis.upenn.edu/~bcpierce/tapl/index.html)
 
 ----
 ## changelog
 * Thu Nov  5 10:02:15 EST 2015: added Plotkin, one paper on den sem/domains
-* Wed Oct 21 11:39:19 EDT 2015: created 
+* Wed Oct 21 11:39:19 EDT 2015: created

--- a/spill.md
+++ b/spill.md
@@ -1,33 +1,28 @@
 N. Adams, D. Kranz, Richard Kelsey, J. Rees, P. Hudak, J. Philbin.
-ORBIT: an optimizing compiler. 
+[ORBIT: an optimizing compiler.](http://dl.acm.org/citation.cfm?id=13333)
 ACM Compiler Construction, 1986, 219--233.
-[url](http://dl.acm.org/citation.cfm?id=13333)
 
-J.W. Backus et al. P. Naur (ed). 
-The report on the algorithmic language Algol 60. 
+J.W. Backus et al. P. Naur (ed).
+[The report on the algorithmic language Algol 60.](http://dl.acm.org/citation.cfm?id=366193.366201&coll=DL&dl=ACM&CFID=553200397&CFTOKEN=50185488)
 Communications of the ACM, 1963, 6(1), 1--17.
-[url](http://dl.acm.org/citation.cfm?id=366193.366201&coll=DL&dl=ACM&CFID=553200397&CFTOKEN=50185488)
 
-K.E. Ivarson. 
-A Programming Language. 
+K.E. Ivarson.
+[A Programming Language.](http://www.jsoftware.com/papers/APL.htm)
 John Wiley & Son's. 1962.
-[url](http://www.jsoftware.com/papers/APL.htm)
 
-Kam & Ullman Monotone data flow analysis frameworks
+Kam & Ullman.
+[Monotone data flow analysis frameworks](http://link.springer.com/article/10.1007/BF00290339#page-1)
 Acta Informatica, 1977, 7, 305--317.
-[url](http://link.springer.com/article/10.1007/BF00290339#page-1)
 
 L. Lamport.
 Time, clocks, and the ordering of events in a distributed system.
 Communications of the ACM, 1978, 21(7), 558--565.
 
 J. McCarthy.
-Recursive functions of symbolic expressions and their computation by machine, part I.
+[Recursive functions of symbolic expressions and their computation by machine, part I.](http://dl.acm.org/citation.cfm?id=367199)
 Communications of the ACM, 1960, 3(4), 184--195
-[url](http://dl.acm.org/citation.cfm?id=367199)
 
-J.C. Reynolds. 
-Types, abstraction and parametric polymorphism.
+J.C. Reynolds.
+[Types, abstraction and parametric polymorphism.](http://www.cse.chalmers.se/edu/year/2010/course/DAT140_Types/Reynolds_typesabpara.pdf)
 Information Processing (IFIP), 1983, 513--523.
 IFIP Congress 1983
-[url](http://www.cse.chalmers.se/edu/year/2010/course/DAT140_Types/Reynolds_typesabpara.pdf)


### PR DESCRIPTION
I don't know if the format was a standard that was followed but I found it harder to read and use. I almost missed the small url link at the end of each line. This change should make it easier to use by most none academics.
